### PR TITLE
Read indexFile from package.json if not specified.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-config-prettier": "2.2.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-node": "5.0.0",
+    "fs-extra": "^4.0.1",
     "glob": "7.1.2",
     "jest": "20.0.4",
     "opener": "1.4.3",

--- a/src/__tests__/__snapshots__/config.spec.js.snap
+++ b/src/__tests__/__snapshots__/config.spec.js.snap
@@ -10,8 +10,6 @@ exports[`config prepareConfig should throw when \`indexFile\` is not a string 2`
 
 exports[`config prepareConfig should throw when \`indexFile\` is not a string 3`] = `"babel-plugin-direct-import: { indexFile } expected to be a string"`;
 
-exports[`config prepareConfig should throw when \`indexFile\` is not a string 4`] = `"babel-plugin-direct-import: { indexFile } expected to be a string"`;
-
 exports[`config prepareConfig should throw when \`indexFileContent\` is an empty string 1`] = `"babel-plugin-direct-import: { indexFileContent } is empty"`;
 
 exports[`config prepareConfig should throw when \`indexFileContent\` is not a string 1`] = `"babel-plugin-direct-import: { indexFileContent } expected to be a string"`;

--- a/src/__tests__/__snapshots__/mapper.spec.js.snap
+++ b/src/__tests__/__snapshots__/mapper.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mapper fulfillConfigExports should throw if no \`indexFile\` could be found 1`] = `"babel-plugin-direct-import: no indexFile specified for __dummy-module and its package.json does not specify \\"module\\" or \\"jsnext:main\\""`;

--- a/src/__tests__/config.spec.js
+++ b/src/__tests__/config.spec.js
@@ -8,6 +8,10 @@ describe("config", () => {
       ).toThrowErrorMatchingSnapshot();
     });
 
+    it("should not throw when given only a name as string", () => {
+      expect(() => prepareConfig("lodash")).not.toThrow();
+    });
+
     it("should throw when `name` is not a string", () => {
       expect(() => prepareConfig({ name: 10 })).toThrowErrorMatchingSnapshot();
       expect(() => prepareConfig({ name: {} })).toThrowErrorMatchingSnapshot();
@@ -31,9 +35,13 @@ describe("config", () => {
       expect(() =>
         prepareConfig({ name: "lodash", indexFile: [] })
       ).toThrowErrorMatchingSnapshot();
+    });
+
+    it("should not throw when `indexFile` is null or undefined", () => {
       expect(() =>
         prepareConfig({ name: "lodash", indexFile: null })
-      ).toThrowErrorMatchingSnapshot();
+      ).not.toThrow();
+      expect(() => prepareConfig({ name: "lodash" })).not.toThrow();
     });
 
     it("should throw when `indexFile` is an empty string", () => {
@@ -75,17 +83,15 @@ describe("config", () => {
       expect(Array.isArray(config)).toBe(true);
     });
 
-    it("should set `name` to `indexFile` if it's value is undefined", () => {
-      expect(prepareConfig({ name: "lodash" })).toEqual([
-        { name: "lodash", indexFile: "lodash", indexFileContent: null }
-      ]);
-    });
-
     it("should create normalized config", () => {
       expect(
         prepareConfig({ name: "lodash", indexFile: "lodash/index" })
       ).toEqual([
         { name: "lodash", indexFile: "lodash/index", indexFileContent: null }
+      ]);
+
+      expect(prepareConfig("material-ui")).toEqual([
+        { name: "material-ui", indexFile: null, indexFileContent: null }
       ]);
     });
   });

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,13 @@ const getUnknownKeys = fp.flow(
 const prepareConfig = fp.flow(
   fp.castArray,
   fp.map(options => {
+    if (fp.isString(options)) {
+      return {
+        name: options,
+        indexFile: null,
+        indexFileContent: null
+      };
+    }
     const { name, indexFile, indexFileContent } = options;
     const unknownKeys = getUnknownKeys(options);
 
@@ -31,9 +38,7 @@ const prepareConfig = fp.flow(
 
     config.name = name;
 
-    if (fp.isUndefined(indexFile)) {
-      config.indexFile = name;
-    } else {
+    if (indexFile != null) {
       if (!fp.isString(indexFile)) {
         throw new Error(
           "babel-plugin-direct-import: { indexFile } expected to be a string"
@@ -48,6 +53,7 @@ const prepareConfig = fp.flow(
     }
 
     if (
+      indexFile != null &&
       config.indexFile !== config.name &&
       config.indexFile.split("/")[0] !== config.name.split("/")[0]
     ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -892,6 +892,14 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+fs-extra@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.1.tgz#7fc0c6c8957f983f57f306a24e5b9ddd8d0dd880"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -963,7 +971,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1587,6 +1595,12 @@ json-stringify-safe@~5.0.1:
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -2430,6 +2444,10 @@ uglify-js@^2.6:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 urlgrey@0.4.4:
   version "0.4.4"


### PR DESCRIPTION
This PR adds support for reading a value for `indexFile` from the `module` or `jsnext:main` field of a package's `package.json`. E.g. material-ui specifies these fields.
It also makes the `indexFile` config property optional and allows specifying a string instead of an object (`"foo"` is a shorthand for `{ name: "foo" }`.

With this patch, the configuration for material-ui with material-ui-icons is as simple as `["material-ui", "material-ui-icons"]`.

To keep the coverage at 100%, I added two tests that create dummy modules that expose the es2015 modules with `jsnext:main` and `module`, respectively.

Resolves #3 