### PR TITLE
Don't use process.cwd() to resolve module files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const fp = require("lodash/fp");
+const { dirname } = require('path')
 const { prepareConfig } = require("./config");
 const { fulfillConfigExports } = require("./mapper");
 
@@ -6,16 +7,19 @@ const fulfillConfigs = fp.memoize(
   fp.flow(
     x => JSON.parse(x),
     prepareConfig,
+    fp.map(x => Object.assign({}, x, { programPath })),
     fp.map(fp.flow(fulfillConfigExports, x => [x.name, x])),
     fp.fromPairs
   )
 );
 
 let configs;
+let programPath;
 
 module.exports = babel => ({
   visitor: {
     Program(path, state) {
+      programPath = dirname(state.file.opts.filename);
       configs = fulfillConfigs(JSON.stringify(state.opts));
     },
     ImportDeclaration(declaration) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,24 +3,23 @@ const { dirname } = require('path')
 const { prepareConfig } = require("./config");
 const { fulfillConfigExports } = require("./mapper");
 
-const fulfillConfigs = fp.memoize(
+// note: memoize uses the first argument as key, so programPath is ignored here, which is expected
+const fulfillConfigs = fp.memoize((opts, programPath) =>
   fp.flow(
     x => JSON.parse(x),
     prepareConfig,
     fp.map(x => Object.assign({}, x, { programPath })),
     fp.map(fp.flow(fulfillConfigExports, x => [x.name, x])),
     fp.fromPairs
-  )
+  )(opts)
 );
 
 let configs;
-let programPath;
 
 module.exports = babel => ({
   visitor: {
     Program(path, state) {
-      programPath = dirname(state.file.opts.filename);
-      configs = fulfillConfigs(JSON.stringify(state.opts));
+      configs = fulfillConfigs(JSON.stringify(state.opts), dirname(state.file.opts.filename));
     },
     ImportDeclaration(declaration) {
       const { types } = babel;

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -25,13 +25,13 @@ function fulfillConfigExports(config) {
     return config;
   }
 
-  let { indexFile, indexFileContent } = config;
+  let { indexFile, indexFileContent, programPath } = config;
 
   const exports = {};
 
   if (!fp.isString(indexFileContent)) {
     if (!fp.isString(indexFile)) {
-      const packageJsonPath = resolveFilename(`${config.name}/package.json`);
+      const packageJsonPath = resolveFilename(`${config.name}/package.json`, programPath);
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
 
       if (fp.isString(packageJson.module)) {
@@ -44,8 +44,7 @@ function fulfillConfigExports(config) {
         );
       }
     }
-
-    const indexFilePath = resolveFilename(indexFile);
+    const indexFilePath = resolveFilename(indexFile, programPath);
     indexFileContent = fs.readFileSync(indexFilePath, "utf-8");
   }
 

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -25,7 +25,8 @@ function fulfillConfigExports(config) {
     return config;
   }
 
-  let { indexFile, indexFileContent, programPath } = config;
+  const { programPath } = config;
+  let { indexFile, indexFileContent } = config;
 
   const exports = {};
 

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -6,12 +6,12 @@ const Module = require("module");
  * @param {String} fileName
  * @returns {String|null}
  */
-function resolveFilename(fileName) {
+function resolveFilename(fileName, relativeTo = process.cwd()) {
   try {
     const parent = new Module();
 
     // eslint-disable-next-line no-underscore-dangle
-    parent.paths = Module._nodeModulePaths(process.cwd());
+    parent.paths = Module._nodeModulePaths(relativeTo);
 
     // eslint-disable-next-line no-underscore-dangle
     return Module._resolveFilename(fileName, parent);


### PR DESCRIPTION
This will resolve the modules relative to the path of the transpiled file (`programPath`) instead of `process.cwd()`, which is the same thing that node would do.

Fixes #5 